### PR TITLE
Re-enabling Docker in RHEL with a Workaround and tests

### DIFF
--- a/nomad/nomad.json
+++ b/nomad/nomad.json
@@ -133,6 +133,19 @@
     },
     {
       "type": "shell",
+      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
+      "inline": [
+        "bash /tmp/nomad/scripts/install-docker.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "bash /tmp/nomad/scripts/install-oracle-jdk.sh"
+      ]
+    },
+    {
+      "type": "shell",
       "environment_vars": [
         "VERSION={{ user `consul_version` }}",
         "URL={{ user `consul_ent_url` }}"
@@ -167,19 +180,13 @@
     },
     {
       "type": "shell",
-      "only": ["amazon-ebs-ubuntu-16.04-systemd"],
+      "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [
-        "bash /tmp/nomad/scripts/install-docker.sh"
+        "cd /tmp/shared/scripts && bash setup-testing.sh",
+        "cd /tmp/nomad && rake spec"
       ]
     },
-    {
-      "type": "shell",
-      "inline": [
-        "bash /tmp/nomad/scripts/install-oracle-jdk.sh",
-        "cd /tmp/shared/scripts && bash setup-testing.sh"
-      ]
-    },
-    {
+     {
       "type": "shell",
       "only": ["amazon-ebs-rhel-7.3-systemd", "amazon-ebs-ubuntu-16.04-systemd"],
       "inline": [

--- a/nomad/scripts/install-docker.sh
+++ b/nomad/scripts/install-docker.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
-set -e
+set -x
+
+YUM=$(which yum 2>/dev/null)
+APT_GET=$(which apt-get 2>/dev/null)
+
+logger "Running"
 
 logger() {
   DT=$(date '+%Y/%m/%d %H:%M:%S')
   echo "$DT $0: $1"
 }
 
-logger "Running"
+if [[ ! -z ${YUM} ]]; then
+  echo "Installing Docker with RHEL Workaround"
+  sudo yum -y install ftp://fr2.rpmfind.net/linux/centos/7.3.1611/extras/x86_64/Packages/container-selinux-2.12-2.gite7096ce.el7.noarch.rpm
+  curl -sSL https://get.docker.com/ | sed -e '365s/redhat/centos/' | sed -e '376s/redhat/centos/' | sudo sh
+elif [[ ! -z ${APT_GET} ]]; then
+  echo "Installing Docker"
+  curl -sSL https://get.docker.com/ | sudo sh
+else
+  logger "Prerequisites not installed due to OS detection failure"
+  exit 1;
+fi
 
-logger "Installing Docker"
-
-curl -sSL https://get.docker.com/ | sudo sh
 sudo sh -c "echo \"DOCKER_OPTS='--dns 127.0.0.1 --dns 8.8.8.8 --dns-search service.consul'\" >> /etc/default/docker"
 
 logger "Complete"

--- a/nomad/spec/java_spec.rb
+++ b/nomad/spec/java_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe command('java -version') do
+  its(:exit_status) { should eq 0 }
+end

--- a/nomad/spec/nomad_spec.rb
+++ b/nomad/spec/nomad_spec.rb
@@ -41,12 +41,7 @@ file('/opt/nomad/data') do
   it { should be_directory }
 end
 
-describe port(4646) do
-  it { should be_listening.with('tcp') }
+describe command('curl http://localhost:4646/v1/status/leader -sL -w "%{http_code}\\n" -o /dev/null') do
+  its(:stdout) { should match /200/ }
 end
-
-describe http_get(8500, 'localhost', '/v1/status/leader') do
-  its(:status) { should eq 200 }
-end
-
 

--- a/shared/scripts/base.sh
+++ b/shared/scripts/base.sh
@@ -22,6 +22,9 @@ APT_GET=$(which apt-get 2>/dev/null)
 if [[ ! -z ${YUM} ]]; then
   logger "RHEL/CentOS system detected"
   logger "Performing updates and installing prerequisites"
+  sudo yum-config-manager --enable rhui-REGION-rhel-server-releases-optional
+  sudo yum-config-manager --enable rhui-REGION-rhel-server-supplementary
+
   sudo yum -y check-update
   sudo yum install -q -y wget unzip bind-utils ruby rubygems ntp
   sudo systemctl start ntpd.service


### PR DESCRIPTION
After new code in the Docker installer that stops the installation when using RHEL, a workaround was added to add a patch at runtime.
I've also re-enabled tests for the images.