### PR TITLE
added setcap cap_ip_lock capability to vault.service

### DIFF
--- a/vault/init/systemd/vault.service
+++ b/vault/init/systemd/vault.service
@@ -6,6 +6,7 @@ After=consul-online.target
 [Service]
 Restart=on-failure
 EnvironmentFile=/etc/vault.d/vault.conf
+ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
 ExecStart=/usr/local/bin/vault server -config /etc/vault.d $FLAGS
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM


### PR DESCRIPTION
I only updated vault/init/systemd/vault.service so far.
But I wonder if vault-secure-intro.service should also be updated?