### PR TITLE
Adding checks to verify setcap is set on the binary

### DIFF
--- a/spec/vault/vault_spec.rb
+++ b/spec/vault/vault_spec.rb
@@ -11,7 +11,7 @@ describe file('/usr/local/bin/consul') do
 end
 
 describe command('/sbin/getcap /usr/local/bin/vault') do
-  its(:stderr) { should match /cap_ipc_lock+ep/ }
+  its(:stdout) { should match /cap_ipc_lock+ep/ }
   its(:exit_status) { should eq 0 }
 end
 

--- a/spec/vault/vault_spec.rb
+++ b/spec/vault/vault_spec.rb
@@ -11,7 +11,7 @@ describe file('/usr/local/bin/consul') do
 end
 
 describe command('/sbin/getcap /usr/local/bin/vault') do
-  its(:stdout) { should match /cap_ipc_lock+ep/ }
+  its(:stdout) { should match /cap_ipc_lock\+ep/ }
   its(:exit_status) { should eq 0 }
 end
 

--- a/spec/vault/vault_spec.rb
+++ b/spec/vault/vault_spec.rb
@@ -10,6 +10,11 @@ describe file('/usr/local/bin/consul') do
   it { should be_executable }
 end
 
+describe command('getcap /usr/local/bin/vault') do
+  its(:stderr) { should match /cap_ipc_lock+ep/ }
+  its(:exit_status) { should eq 0 }
+end
+
 describe service('vault') do
   it { should be_enabled }
   it { should be_running }

--- a/spec/vault/vault_spec.rb
+++ b/spec/vault/vault_spec.rb
@@ -10,7 +10,7 @@ describe file('/usr/local/bin/consul') do
   it { should be_executable }
 end
 
-describe command('getcap /usr/local/bin/vault') do
+describe command('/sbin/getcap /usr/local/bin/vault') do
   its(:stderr) { should match /cap_ipc_lock+ep/ }
   its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
As @rberlind recently expressed concerns on builds not marking the vault binary with the right capabilities (for example, in upgrade cases), I'm adding a test to verify that Vault has the right capabilities.

This will 99.9% pass in our builds, but it helps if the tests are used independently of HashiCorp's Packer Templates

Signed-off-by: Nicolas Corrarello <nicolas@corrarello.com>