### PR TITLE
Add spaces to outer brackets

### DIFF
--- a/nomad/scripts/install-nomad.sh
+++ b/nomad/scripts/install-nomad.sh
@@ -15,7 +15,7 @@ NOMAD_ENV_VARS=${NOMAD_CONFIG_DIR}/nomad.conf
 NOMAD_PROFILE_SCRIPT=/etc/profile.d/nomad.sh
 
 echo "Downloading Nomad ${NOMAD_VERSION}"
-[200 -ne $(curl --write-out %{http_code} --silent --output /tmp/${NOMAD_ZIP} ${NOMAD_URL})] && exit 1
+[ 200 -ne $(curl --write-out %{http_code} --silent --output /tmp/${NOMAD_ZIP} ${NOMAD_URL}) ] && exit 1
 
 echo "Installing Nomad"
 sudo unzip -o /tmp/${NOMAD_ZIP} -d ${NOMAD_DIR}

--- a/vault/scripts/install-vault.sh
+++ b/vault/scripts/install-vault.sh
@@ -15,7 +15,7 @@ VAULT_ENV_VARS=${VAULT_CONFIG_DIR}/vault.conf
 VAULT_PROFILE_SCRIPT=/etc/profile.d/vault.sh
 
 echo "Downloading Vault ${VAULT_VERSION}"
-[200 -ne $(curl --write-out %{http_code} --silent --output /tmp/${VAULT_ZIP} ${VAULT_URL})] && exit 1
+[ 200 -ne $(curl --write-out %{http_code} --silent --output /tmp/${VAULT_ZIP} ${VAULT_URL}) ] && exit 1
 
 echo "Installing Vault"
 sudo unzip -o /tmp/${VAULT_ZIP} -d ${VAULT_DIR}


### PR DESCRIPTION
Without proper spacing between the brackets, bash will return a "bash: [200: command not found"