### PR TITLE
support/install dependencies on alpine

### DIFF
--- a/nomad/scripts/install-nomad.sh
+++ b/nomad/scripts/install-nomad.sh
@@ -3,6 +3,11 @@ set -x
 
 echo "Running"
 
+APK=$(which apk 2>/dev/null)
+if [[ ! -z ${APK} ]]; then
+  apk add --no-cache gcompat
+fi
+
 NOMAD_VERSION=${VERSION}
 NOMAD_ZIP=nomad_${NOMAD_VERSION}_linux_amd64.zip
 NOMAD_URL=${URL:-https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/${NOMAD_ZIP}}


### PR DESCRIPTION
workaround based on https://github.com/hashicorp/nomad/issues/1779 to avoid
```
config.vm.provision "shell", inline: "apk add --no-cache gcompat && curl https://raw.githubusercontent.com/hashicorp/guides-configuration/master/nomad/scripts/install-nomad.sh | bash",
    env: {
      "VERSION" => "0.8.6",
      "URL" => "",
      "USER" => "root",
      "GROUP" => "root",
    }
```